### PR TITLE
Solved compilation errors on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: btdwm
 PHONY += btdwm
 btdwm: $(objects)
 	echo -e "  LD      $<"
-	$(CC) $(LDFLAGS) -o $@ $(objects)
+	$(CC) -o $@ $(objects) $(LDFLAGS)
 
 PHONY += clean
 clean:

--- a/config.mk
+++ b/config.mk
@@ -2,7 +2,7 @@ CC		:= gcc
 
 PREFIX		:= /opt/btdwm
 
-PKGLIST		= xcb-aux xcb-cursor xcb-ewmh xcb-icccm xcb-keysyms xcb-xinerama xcb pangocairo pango libnotify
+PKGLIST		= xcb-aux xcb-cursor xcb-ewmh xcb-icccm xcb-keysyms xcb-xinerama xcb pangocairo pango libnotify xau x11 xdmcp
 
 MAKEFLAGS	:= -s
 


### PR DESCRIPTION
The GNU loader ld uses library dependency order to link faster. Without the changes in Makefile, I get a lot of unresolved depdendencies errors on Ubuntu 16.04. Either change the order like in this PR or add --start-group to the very beginning of LDFLAGS to suppress the order optimization. Also, there were unresolved dependencies in the external libraries which are found in the added packages in config.mk.

Is this being developed and used on OSX? Is that why this is working for you guys?

Thanks!